### PR TITLE
Disable integrated Notify

### DIFF
--- a/mod_info.lua
+++ b/mod_info.lua
@@ -3,7 +3,7 @@
 -- Documentation for the extended FAF mod_info.lua format can be found here:
 -- https://github.com/FAForever/fa/wiki/mod_info.lua-documentation
 name = "Phantom-X"
-version = 253
+version = 254
 copyright = "Unknown"
 description = "Phantom-X game mod for Forged Alliance Forever"
 author = "Original code by novaprim3.  Additional code by Duck_42 and mead."

--- a/phantomxhook/lua/sim/Unit.lua
+++ b/phantomxhook/lua/sim/Unit.lua
@@ -25,3 +25,6 @@ Unit.OnKilled = function(self, instigator, type, overkillRatio)
     end
     PhantomOriginalOnKilled(self, instigator, type, overkillRatio)
 end
+
+Unit.SendNotifyMessage = function(self, trigger, source) -- Disable Notify
+end


### PR DESCRIPTION
This prevents integrated Notify from sending messages or displaying overlays. It doesn't interfere with enhancement queuing.