### PR TITLE
Phantom "How to play" Engineer trading

### DIFF
--- a/modules/help_ui.lua
+++ b/modules/help_ui.lua
@@ -45,7 +45,7 @@ helpText = helpText..'-No Reveal After Death\n'
 helpText = helpText..'This option does pretty much what you\'d think.  When enabled, the game does not reveal a player\'s affiliation (phantom or innocent) when they die. This was created as a hardcore phantom option and was intended for use in no reveal games. As in normal phantom, the game will end when all phantoms are dead or when the last phantom kills off the other remaining player. As you might expect, this option can lead to some pretty paranoid game play.\n\n\n'
 helpText = helpText..'Other Rules\n\n'
 helpText = helpText..' -Engineer Trading\n'
-helpText = helpText..'    Although not often explicitly stated, engineer trading is usually prohibited in phantom games. Host should make it clear before the game begins if engineer trading is allowed. Stealing (capturing) engineers is usually allowed as long as it\'s not just a disguised trade.\n'
+helpText = helpText..'    Although not often explicitly stated, engineer trading is usually prohibited in phantom games. Therefore host should explicity say that it is allowed if it is, to avoid confusion. Stealing (capturing) engineers is usually allowed as long as it\'s not just a disguised trade.\n'
 
 function ShowPhantomXHelpDialog(inParent)
 	local dialogContent = Group(inParent)

--- a/modules/help_ui.lua
+++ b/modules/help_ui.lua
@@ -45,7 +45,7 @@ helpText = helpText..'-No Reveal After Death\n'
 helpText = helpText..'This option does pretty much what you\'d think.  When enabled, the game does not reveal a player\'s affiliation (phantom or innocent) when they die. This was created as a hardcore phantom option and was intended for use in no reveal games. As in normal phantom, the game will end when all phantoms are dead or when the last phantom kills off the other remaining player. As you might expect, this option can lead to some pretty paranoid game play.\n\n\n'
 helpText = helpText..'Other Rules\n\n'
 helpText = helpText..' -Engineer Trading\n'
-helpText = helpText..'    Although not often explicitly stated, engineer trading is usually prohibited in phantom games. If you plan on trading engineers, be sure to check with the host about whether or not trading is permitted.  Stealing (capturing) engineers is usually allowed as long as it\'s not just a disguised trade.\n'
+helpText = helpText..'    Although not often explicitly stated, engineer trading is usually prohibited in phantom games. Host should make it clear before the game begins if engineer trading is allowed. Stealing (capturing) engineers is usually allowed as long as it\'s not just a disguised trade.\n'
 
 function ShowPhantomXHelpDialog(inParent)
 	local dialogContent = Group(inParent)

--- a/phantomxhook/lua/ui/lobby/lobbyOptions.lua
+++ b/phantomxhook/lua/ui/lobby/lobbyOptions.lua
@@ -1,6 +1,6 @@
         table.insert(globalOpts,
         {
-            default = 3,
+            default = 4,
             label = "<LOC phantomx_0001>P-X: Bonus Multiplier",
             help = "<LOC phantomx_0002>Percentage of the standard bonus that phantoms and paladins will receive.",
             key = 'PhantomBonusMultiplier',


### PR DESCRIPTION
The current helptext for Phantom reguarding engineer trading is not ideal. Because as it is the host can "secretly" say that it is allowed(according to the "how to play"). I changed it to reflext how it shuld be done

