### PR TITLE
Disables display of allies resources on scoreboard

### DIFF
--- a/phantomxhook/lua/simInit.lua
+++ b/phantomxhook/lua/simInit.lua
@@ -1,11 +1,11 @@
-#****************************************************************************
-#**
-#**  File     :  /hook/lua/simInit.lua
-#**  Author(s):  novaprim3
-#**
-#**  Summary  :  Multi-Phantom Mod for Forged Alliance
-#**
-#****************************************************************************
+--***************************************************************************
+--*
+--*  File     :  /hook/lua/simInit.lua
+--*  Author(s):  novaprim3
+--*
+--*  Summary  :  Multi-Phantom Mod for Forged Alliance
+--*
+--***************************************************************************
 local modPath = 'Phantom-X'
 
 function ShuffleStartPositions(syncNewPositions) -- Disable spawn shuffling and syncing since everyone starts allied
@@ -19,4 +19,5 @@ function BeginSession()
     if( tonumber(ScenarioInfo.Options.Phantom_Meteor)) == 1 then
         ForkThread(import('/modules/meteors.lua').MeteorsThread)
     end
+    import('/lua/sim/score.lua').alliesScore = false
 end


### PR DESCRIPTION
There were requests to do so. If it's not necessary, I don't care.
https://faforever.zulipchat.com/#narrow/stream/203495-game-development/topic/Phantom
before
![2](https://user-images.githubusercontent.com/5648030/75855836-f0c4af00-5e14-11ea-865a-e4643f32efc2.png)
after
![1](https://user-images.githubusercontent.com/5648030/75855800-de4a7580-5e14-11ea-9356-3b87e1e069c4.png)
Requires https://github.com/FAForever/fa/pull/2982