### PR TITLE
Fix death issue

### DIFF
--- a/phantomxhook/lua/aibrain.lua
+++ b/phantomxhook/lua/aibrain.lua
@@ -12,12 +12,6 @@ AIBrain.OnDefeat = function(self)
         end
         ###end sorian AI bit
 
-        # seems that FA send the OnDeath twice : one when losing, the other when disconnecting (function AbandonedByPlayer).
-        # But we only want it one time !
-
-        SetArmyOutOfGame(self:GetArmyIndex())
-
-
         if math.floor(self:GetArmyStat("FAFLose",0.0).Value) != -1 then
             self:AddArmyStat("FAFLose", -1)
         end

--- a/phantomxhook/lua/aibrain.lua
+++ b/phantomxhook/lua/aibrain.lua
@@ -12,6 +12,8 @@ AIBrain.OnDefeat = function(self)
         end
         ###end sorian AI bit
 
+        SetArmyOutOfGame(self:GetArmyIndex())
+
         if math.floor(self:GetArmyStat("FAFLose",0.0).Value) != -1 then
             self:AddArmyStat("FAFLose", -1)
         end

--- a/phantomxhook/lua/aibrain.lua
+++ b/phantomxhook/lua/aibrain.lua
@@ -15,10 +15,6 @@ AIBrain.OnDefeat = function(self)
         # seems that FA send the OnDeath twice : one when losing, the other when disconnecting (function AbandonedByPlayer).
         # But we only want it one time !
 
-        if ArmyIsOutOfGame(self:GetArmyIndex()) then
-            return
-        end
-
         SetArmyOutOfGame(self:GetArmyIndex())
 
 


### PR DESCRIPTION
Removes a check that seems to be unneeded. Resolves the issue of units remaining alive on death. Tested with ai and in localhost game with 2 fa instances.