### PR TITLE
Added random initializer snippet

### DIFF
--- a/lua/PhantomSim.lua
+++ b/lua/PhantomSim.lua
@@ -123,10 +123,14 @@ function PhantomMainThread()
 	cur.config.balance_multiplier = (tonumber(ScenarioInfo.Options.PhantomBonusMultiplier))/100.0
 	cur.config.paladin_bonus = (tonumber(ScenarioInfo.Options.PhantomPaladinBonus))/100.0
 	cur.config.paladin_coefficient = (tonumber(ScenarioInfo.Options.PhantomPaladinCoefficient))
-    cur.config.death_reveal = (tonumber(ScenarioInfo.Options.Phantom_DeathReveal))
-    cur.config.paladin_marks = (tonumber(ScenarioInfo.Options.Phantom_PaladinMarks))
+	cur.config.death_reveal = (tonumber(ScenarioInfo.Options.Phantom_DeathReveal))
+	cur.config.paladin_marks = (tonumber(ScenarioInfo.Options.Phantom_PaladinMarks))
 	cur.config.autobalance = (tonumber(ScenarioInfo.Options.Phantom_AutoBalance))
 	cur.config.phantnumber = (tonumber(ScenarioInfo.Options.Phantom_PhantNumber))
+	
+	-- Make random random again
+	math.randomseed(os.time())
+	math.random(); math.random(); math.random();
 	
 	-- Map coefficient values
 	if cur.config.paladin_coefficient == 0 then


### PR DESCRIPTION
The math.random calls seem to be not random, as we have notices one person is _always_ the phantom.
Searching online this seems to be a problem with luas pseudorandom generator.

I have no idea how to test if this is working correctly, though. But the change is small and should be fine.

references: 
https://stackoverflow.com/questions/30641907/lua-5-1-4-math-random-not-actually-random
http://lua-users.org/lists/lua-l/2007-03/msg00564.html